### PR TITLE
Add docs deploy concurrency guard and Sienna aggregate refresh dispatch.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,13 @@ on:
     tags: '*'
   pull_request:
 
+# Prevent simultaneous gh-pages deployments (tag + branch race condition).
+# PR previews each get their own group and cancel on new pushes.
+# All other deploys (main, tags) share one group and queue instead of cancel.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.event.pull_request.number) || 'docs-deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,3 +30,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: julia --project=docs --color=yes docs/make.jl
+
+      - name: Trigger Sienna docs aggregate refresh
+        if: github.event_name != 'pull_request' && success()
+        continue-on-error: true
+        env:
+          SIENNA_DOCS_DISPATCH_TOKEN: ${{ secrets.SIENNA_DOCS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$SIENNA_DOCS_DISPATCH_TOKEN" ]; then
+            echo "SIENNA_DOCS_DISPATCH_TOKEN not set; skipping dispatch"
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $SIENNA_DOCS_DISPATCH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/Sienna-Platform/Sienna/dispatches \
+            -d "{\"event_type\":\"sienna-docs-refresh\",\"client_payload\":{\"package\":\"${{ github.repository }}\",\"ref\":\"${{ github.ref }}\",\"sha\":\"${{ github.sha }}\"}}"


### PR DESCRIPTION
Serialize main/tag docs deploys while allowing PR preview cancel; notify the Sienna site after successful non-PR docs publishes.